### PR TITLE
Update discover_root.toit to handle new error

### DIFF
--- a/examples/discover_root.toit
+++ b/examples/discover_root.toit
@@ -54,6 +54,8 @@ binary_split names/List certs/List -> none:
       return
     if exception.to_string.starts_with "X509 - Certificate verification failed":
       return
+    if exception.to_string.starts_with "Unknown root certificate":
+      return
     throw exception
 
   if names.size == 1:


### PR DESCRIPTION
I'm not sure what could changed, but I'm receiving this error:
```
Unknown root certificate: 'C=US, O=Internet Security Research Group, CN=ISRG Root X1'
Certificate error 0x0008: 'C=US, O=Let's Encrypt, CN=R11'
NOT_TRUSTED
  0: tls-error_                <sdk>/tls/session.toit:1147:3
```

Adding this check the script runs properly.

- Tested on an ESP32 sdk-version: v2.0.0-alpha.164 
- Tested on MacOS Sequoia 15.1 (24B83)
Same error in both 