### PR TITLE
Add discover-root-test.

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a Zero-Clause BSD license that can
 # be found in the tests/TESTS_LICENSE file.
 
-file(GLOB TESTS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "*_test.toit")
+file(GLOB TESTS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "*_test.toit" "*-test.toit")
 
 set(TOIT_EXEC "toit.run" CACHE FILEPATH "The executable used to run the tests")
 set(TPKG_EXEC "toit.pkg" CACHE FILEPATH "The executable used to install the packages")

--- a/tests/discover-root-test.toit
+++ b/tests/discover-root-test.toit
@@ -1,0 +1,10 @@
+// Copyright (C) 2024 Toitware ApS.
+// Use of this source code is governed by a Zero-Clause BSD license that can
+// be found in the tests/TESTS_LICENSE file.
+
+import expect show *
+import ..examples.discover-root as discover-root
+
+main:
+  result := discover-root.discover-root --uri="https://toitlang.org"
+  expect-not-null result

--- a/tests/package.lock
+++ b/tests/package.lock
@@ -1,5 +1,12 @@
+sdk: ^2.0.0-alpha.145
 prefixes:
   certificate_roots: ..
+  http: pkg-http
 packages:
   ..:
     path: ..
+  pkg-http:
+    url: github.com/toitlang/pkg-http
+    name: http
+    version: 2.8.0
+    hash: 81754d64fe466cd00cc494ec515da8749bf04975

--- a/tests/package.lock
+++ b/tests/package.lock
@@ -1,4 +1,4 @@
-sdk: ^2.0.0-alpha.145
+sdk: ^2.0.0-alpha.79
 prefixes:
   certificate_roots: ..
   http: pkg-http
@@ -8,5 +8,5 @@ packages:
   pkg-http:
     url: github.com/toitlang/pkg-http
     name: http
-    version: 2.8.0
-    hash: 81754d64fe466cd00cc494ec515da8749bf04975
+    version: 2.6.0
+    hash: 97bdea9f0f0c78bd41d85d8ac071527caa76b09d

--- a/tests/package.yaml
+++ b/tests/package.yaml
@@ -3,4 +3,4 @@ dependencies:
     path: ..
   http:
     url: github.com/toitlang/pkg-http
-    version: ^2.8.0
+    version: ^2.6.0

--- a/tests/package.yaml
+++ b/tests/package.yaml
@@ -1,3 +1,6 @@
 dependencies:
   certificate_roots:
     path: ..
+  http:
+    url: github.com/toitlang/pkg-http
+    version: ^2.8.0


### PR DESCRIPTION
Add test to make sure the `discover_root` example is working. See #45.